### PR TITLE
chore: release v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-local-provider",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "license": "MIT",
   "description": "OpenCode plugin that adds a 'local' provider with auto-detection for Ollama, LMStudio, llama.cpp, vLLM, and Exo",


### PR DESCRIPTION
## Summary
- Bump package version to 0.1.6 for the next release.

## Verification
- bun run typecheck
- bun run build
- bun test ./tests/config.test.ts
- bun test ./tests/opencode.models.test.ts

## Notes
- Full `bun test ./tests` timed out after 120 seconds while running provider tests.