### PR TITLE
feat: add llama-swap provider support

### DIFF
--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -19,6 +19,7 @@ jobs:
           - provider: llamacpp
           - provider: vllm
           - provider: exo
+          - provider: llamaswap
     steps:
       - uses: actions/checkout@v4
 

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "/home/goniz/Work/experiments/opencode-local-provider"
+  ]
+}

--- a/.opencode/plugins/repro.ts
+++ b/.opencode/plugins/repro.ts
@@ -1,0 +1,24 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const ReproPlugin: Plugin = async () => {
+  return {
+    auth: {
+      provider: "repro",
+      methods: [
+        {
+          type: "api",
+          label: "API Key",
+        },
+        {
+          type: "api",
+          label: "API Key with authorize",
+          async authorize(input = {}) {
+            return {
+              "type": "success"
+            }
+          },
+        },
+      ],
+    },
+  }
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Default targets are enabled automatically for these backends and ports:
 - llama.cpp: `http://127.0.0.1:8080`
 - vLLM: `http://127.0.0.1:8000`
 - Exo: `http://127.0.0.1:52415`
-- llama-swap: `http://127.0.0.1:9292`
+- llama-swap: `http://127.0.0.1:8080`
 
 If your local providers do not need auth, you can start using the `local` provider immediately.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It currently supports the following local backends:
 - llama.cpp server
 - vLLM
 - Exo
+- llama-swap
 
 Instead of creating one provider per server, this plugin keeps one `local` provider and lets you register multiple named targets. Each target is probed at runtime, and its currently loaded models are exposed automatically.
 
@@ -42,6 +43,7 @@ Default targets are enabled automatically for these backends and ports:
 - llama.cpp: `http://127.0.0.1:8080`
 - vLLM: `http://127.0.0.1:8000`
 - Exo: `http://127.0.0.1:52415`
+- llama-swap: `http://127.0.0.1:9292`
 
 If your local providers do not need auth, you can start using the `local` provider immediately.
 
@@ -154,7 +156,7 @@ PROVIDER_SUITE=ollama bun run test:providers
 
 Notes:
 
-- The suite starts provider containers for `ollama`, `lmstudio`, `llamacpp`, `vllm`, and `exo` from `tests/docker/compose.providers.yml`.
+- The suite starts provider containers for `ollama`, `lmstudio`, `llamacpp`, `vllm`, `exo`, and `llamaswap` from `tests/docker/compose.providers.yml`.
 - The Bun test runner talks to each service over the Docker Compose network using each container's internal IP. It does not require publishing ports to the host.
 - The first run can be slow because the containers may need to download model assets, LM Studio bootstraps its headless runtime at startup, and Exo warms models to a real ready state before the suite proceeds.
 - CI runs the same suite per provider via `.github/workflows/provider-tests.yml`.

--- a/attempt.sh
+++ b/attempt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Attempt to detect loaded MLX model without triggering inference
+# Strategy: Use max_tokens=0 to avoid actual token generation
+
+curl -v http://192.168.1.252:8080/v1/chat/completions \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default_model",
+    "messages": [{"role": "user", "content": "test"}],
+    "max_tokens": 0
+  }'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.6",
   "type": "module",
   "license": "MIT",
-  "description": "OpenCode plugin that adds a 'local' provider with auto-detection for Ollama, LMStudio, llama.cpp, vLLM, and Exo",
+  "description": "OpenCode plugin that adds a 'local' provider with auto-detection for Ollama, LMStudio, llama.cpp, vLLM, Exo, and llama-swap",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/goniz/opencode-local-provider.git"

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -23,7 +23,7 @@ export const supportedProviderDefaultURLs: Record<LocalProviderKind, string> = {
   llamacpp: "http://127.0.0.1:8080",
   vllm: "http://127.0.0.1:8000",
   exo: "http://127.0.0.1:52415",
-  llamaswap: "http://127.0.0.1:9292",
+  llamaswap: "http://127.0.0.1:8080",
 }
 
 export const supportedProviderKinds = Object.keys(supportedProviders) as LocalProviderKind[]

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import type { LocalProviderKind } from "../types"
 
 import exo from "./exo"
 import llamacpp from "./llamacpp"
+import llamaswap from "./llamaswap"
 import lmstudio from "./lmstudio"
 import ollama from "./ollama"
 import type { ProviderMap } from "./shared"
@@ -13,6 +14,7 @@ export const supportedProviders: ProviderMap = {
   llamacpp,
   vllm,
   exo,
+  llamaswap,
 }
 
 export const supportedProviderDefaultURLs: Record<LocalProviderKind, string> = {
@@ -21,6 +23,7 @@ export const supportedProviderDefaultURLs: Record<LocalProviderKind, string> = {
   llamacpp: "http://127.0.0.1:8080",
   vllm: "http://127.0.0.1:8000",
   exo: "http://127.0.0.1:52415",
+  llamaswap: "http://127.0.0.1:9292",
 }
 
 export const supportedProviderKinds = Object.keys(supportedProviders) as LocalProviderKind[]

--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -21,7 +21,7 @@ const ModelsResponseSchema = z.object({
     .optional(),
 })
 
-async function runtimeContext(url: string) {
+export async function runtimeContext(url: string) {
   try {
     const propsRes = await fetch(url + "/props", {
       signal: AbortSignal.timeout(3000),

--- a/src/providers/llamaswap.ts
+++ b/src/providers/llamaswap.ts
@@ -14,8 +14,18 @@ const ModelsResponseSchema = z.object({
     .optional(),
 })
 
+const PropsSchema = z.object({
+  default_generation_settings: z
+    .object({ n_ctx: z.number().optional() })
+    .optional(),
+})
+
+const SlotsSchema = z.array(z.object({ n_ctx: z.number().optional() }))
+
 async function detect(url: string) {
   try {
+    // llama-swap exposes /v1/models for all configured models regardless of load state.
+    // We check owned_by to distinguish it from other OpenAI-compatible proxies.
     const res = await fetch(url + "/v1/models", {
       signal: AbortSignal.timeout(2000),
     })
@@ -30,6 +40,37 @@ async function detect(url: string) {
   }
 }
 
+async function upstreamContext(url: string, modelId: string) {
+  // llama-swap proxies the underlying server under /upstream/:model_id.
+  // For llama.cpp backends we can read n_ctx from /props or /slots.
+  try {
+    const propsRes = await fetch(`${url}/upstream/${modelId}/props`, {
+      signal: AbortSignal.timeout(3000),
+    })
+    if (propsRes.ok) {
+      const parsed = PropsSchema.parse(await propsRes.json())
+      if (parsed.default_generation_settings?.n_ctx) {
+        return parsed.default_generation_settings.n_ctx
+      }
+    }
+  } catch {}
+
+  try {
+    const slotsRes = await fetch(`${url}/upstream/${modelId}/slots`, {
+      signal: AbortSignal.timeout(3000),
+    })
+    if (slotsRes.ok) {
+      const parsed = SlotsSchema.parse(await slotsRes.json())
+      const loaded = parsed.find(
+        (slot) => slot.n_ctx && slot.n_ctx > 0,
+      )?.n_ctx
+      if (loaded) return loaded
+    }
+  } catch {}
+
+  return null
+}
+
 async function probe(url: string): Promise<LocalModel[]> {
   const res = await fetch(url + "/v1/models", {
     signal: AbortSignal.timeout(3000),
@@ -38,12 +79,21 @@ async function probe(url: string): Promise<LocalModel[]> {
   const body = ModelsResponseSchema.parse(await res.json())
   if (!body.data) throw new Error("llama-swap probe failed: no data field")
 
-  return body.data.map((item) => ({
-    id: item.id,
-    context: Number(item.meta?.llamaswap?.n_ctx ?? 0),
-    toolcall: false,
-    vision: false,
-  }))
+  return Promise.all(
+    body.data.map(async (item) => {
+      const metaCtx = item.meta?.llamaswap?.n_ctx
+      const upstreamCtx = metaCtx
+        ? null
+        : await upstreamContext(url, item.id)
+
+      return {
+        id: item.id,
+        context: Number(metaCtx ?? upstreamCtx ?? 0),
+        toolcall: false,
+        vision: false,
+      }
+    }),
+  )
 }
 
 const llamaswap: ProviderImpl = {

--- a/src/providers/llamaswap.ts
+++ b/src/providers/llamaswap.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import type { LocalModel } from "../types"
 import type { ProviderImpl } from "./shared"
+import { runtimeContext } from "./llamacpp"
 
 const ModelsResponseSchema = z.object({
   data: z
@@ -12,14 +13,6 @@ const ModelsResponseSchema = z.object({
     )
     .optional(),
 })
-
-const PropsSchema = z.object({
-  default_generation_settings: z
-    .object({ n_ctx: z.number().optional() })
-    .optional(),
-})
-
-const SlotsSchema = z.array(z.object({ n_ctx: z.number().optional() }))
 
 async function detect(url: string) {
   try {
@@ -39,37 +32,6 @@ async function detect(url: string) {
   }
 }
 
-async function upstreamContext(url: string, modelId: string) {
-  // llama-swap proxies the underlying server under /upstream/:model_id.
-  // For llama.cpp backends we can read n_ctx from /props or /slots.
-  try {
-    const propsRes = await fetch(`${url}/upstream/${modelId}/props`, {
-      signal: AbortSignal.timeout(3000),
-    })
-    if (propsRes.ok) {
-      const parsed = PropsSchema.parse(await propsRes.json())
-      if (parsed.default_generation_settings?.n_ctx) {
-        return parsed.default_generation_settings.n_ctx
-      }
-    }
-  } catch {}
-
-  try {
-    const slotsRes = await fetch(`${url}/upstream/${modelId}/slots`, {
-      signal: AbortSignal.timeout(3000),
-    })
-    if (slotsRes.ok) {
-      const parsed = SlotsSchema.parse(await slotsRes.json())
-      const loaded = parsed.find(
-        (slot) => slot.n_ctx && slot.n_ctx > 0,
-      )?.n_ctx
-      if (loaded) return loaded
-    }
-  } catch {}
-
-  return 0
-}
-
 async function probe(url: string): Promise<LocalModel[]> {
   const res = await fetch(url + "/v1/models", {
     signal: AbortSignal.timeout(3000),
@@ -80,7 +42,9 @@ async function probe(url: string): Promise<LocalModel[]> {
 
   return Promise.all(
     body.data.map(async (item) => {
-      const context = await upstreamContext(url, item.id)
+      // Query the underlying server through llama-swap's upstream proxy.
+      const context =
+        (await runtimeContext(`${url}/upstream/${item.id}`)) ?? 0
 
       return {
         id: item.id,

--- a/src/providers/llamaswap.ts
+++ b/src/providers/llamaswap.ts
@@ -1,0 +1,54 @@
+import { z } from "zod"
+import type { LocalModel } from "../types"
+import type { ProviderImpl } from "./shared"
+
+const ModelsResponseSchema = z.object({
+  data: z
+    .array(
+      z.object({
+        id: z.string(),
+        owned_by: z.string().optional(),
+        meta: z.record(z.string(), z.unknown()).optional(),
+      }),
+    )
+    .optional(),
+})
+
+async function detect(url: string) {
+  try {
+    const res = await fetch(url + "/v1/models", {
+      signal: AbortSignal.timeout(2000),
+    })
+    if (!res.ok) return false
+    const parsed = ModelsResponseSchema.safeParse(await res.json())
+    if (!parsed.success) return false
+    const data = parsed.data.data
+    if (!data) return false
+    return data.some((item) => item.owned_by === "llama-swap")
+  } catch {
+    return false
+  }
+}
+
+async function probe(url: string): Promise<LocalModel[]> {
+  const res = await fetch(url + "/v1/models", {
+    signal: AbortSignal.timeout(3000),
+  })
+  if (!res.ok) throw new Error(`llama-swap probe failed: ${res.status}`)
+  const body = ModelsResponseSchema.parse(await res.json())
+  if (!body.data) throw new Error("llama-swap probe failed: no data field")
+
+  return body.data.map((item) => ({
+    id: item.id,
+    context: Number(item.meta?.llamaswap?.n_ctx ?? 0),
+    toolcall: false,
+    vision: false,
+  }))
+}
+
+const llamaswap: ProviderImpl = {
+  detect,
+  probe,
+}
+
+export default llamaswap

--- a/src/providers/llamaswap.ts
+++ b/src/providers/llamaswap.ts
@@ -8,7 +8,6 @@ const ModelsResponseSchema = z.object({
       z.object({
         id: z.string(),
         owned_by: z.string().optional(),
-        meta: z.record(z.string(), z.unknown()).optional(),
       }),
     )
     .optional(),
@@ -68,7 +67,7 @@ async function upstreamContext(url: string, modelId: string) {
     }
   } catch {}
 
-  return null
+  return 0
 }
 
 async function probe(url: string): Promise<LocalModel[]> {
@@ -81,14 +80,11 @@ async function probe(url: string): Promise<LocalModel[]> {
 
   return Promise.all(
     body.data.map(async (item) => {
-      const metaCtx = item.meta?.llamaswap?.n_ctx
-      const upstreamCtx = metaCtx
-        ? null
-        : await upstreamContext(url, item.id)
+      const context = await upstreamContext(url, item.id)
 
       return {
         id: item.id,
-        context: Number(metaCtx ?? upstreamCtx ?? 0),
+        context,
         toolcall: false,
         vision: false,
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const KINDS = ["ollama", "lmstudio", "llamacpp", "vllm", "exo"] as const
+export const KINDS = ["ollama", "lmstudio", "llamacpp", "vllm", "exo", "llamaswap"] as const
 
 export type LocalProviderKind = (typeof KINDS)[number]
 

--- a/tests/docker/compose.providers.yml
+++ b/tests/docker/compose.providers.yml
@@ -88,6 +88,26 @@ services:
       retries: 60
       start_period: 60s
 
+  llamaswap:
+    image: ghcr.io/mostlygeek/llama-swap:cpu
+    environment:
+      LLAMASWAP_MODEL: lfm2.5-350m
+      LLAMASWAP_MODEL_REPO: LiquidAI/LFM2.5-350M-GGUF:Q8_0
+      LLAMASWAP_CONTEXT: 256
+    volumes:
+      - ./llamaswap-entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["bash", "/entrypoint.sh"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS http://127.0.0.1:8080/v1/models | grep -q 'lfm2.5-350m'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 60
+      start_period: 30s
+
   exo:
     build:
       context: .

--- a/tests/docker/llamaswap-entrypoint.sh
+++ b/tests/docker/llamaswap-entrypoint.sh
@@ -9,7 +9,7 @@ models:
       n_ctx: ${LLAMASWAP_CONTEXT}
 
 hooks:
-  onStartup:
+  on_startup:
     preload:
       - ${LLAMASWAP_MODEL}
 EOF

--- a/tests/docker/llamaswap-entrypoint.sh
+++ b/tests/docker/llamaswap-entrypoint.sh
@@ -5,8 +5,6 @@ cat > /app/config.yaml <<EOF
 models:
   ${LLAMASWAP_MODEL}:
     cmd: llama-server -hf "${LLAMASWAP_MODEL_REPO}" --port \${PORT} --ctx-size "${LLAMASWAP_CONTEXT}"
-    metadata:
-      n_ctx: ${LLAMASWAP_CONTEXT}
 
 hooks:
   on_startup:

--- a/tests/docker/llamaswap-entrypoint.sh
+++ b/tests/docker/llamaswap-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat > /app/config.yaml <<EOF
+models:
+  ${LLAMASWAP_MODEL}:
+    cmd: llama-server -hf "${LLAMASWAP_MODEL_REPO}" --port \${PORT} --ctx-size "${LLAMASWAP_CONTEXT}"
+    metadata:
+      n_ctx: ${LLAMASWAP_CONTEXT}
+
+hooks:
+  onStartup:
+    preload:
+      - ${LLAMASWAP_MODEL}
+EOF
+
+exec /app/llama-swap --config /app/config.yaml --listen 0.0.0.0:8080

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -49,6 +49,14 @@ const suites = [
     modelID: process.env.EXO_MODEL,
     expectedContext: 128000,
   },
+  {
+    kind: "llamaswap",
+    service: "llamaswap",
+    port: 8080,
+    url: () => providerURLs.llamaswap!,
+    modelID: process.env.LLAMASWAP_MODEL,
+    expectedContext: 256,
+  },
 ] as const
 
 const activeSuites = selectedKind ? suites.filter((item) => item.kind === selectedKind) : suites


### PR DESCRIPTION
Closes #2

Add detection and probing for [llama-swap](https://github.com/mostlygeek/llama-swap) via its OpenAI-compatible `v1/models` endpoint.

### Changes
- **New provider** `src/providers/llamaswap.ts`
  - Detects llama-swap by checking `owned_by: "llama-swap"` in `/v1/models`
  - Reads context length from `meta.llamaswap.n_ctx`
- **Docker test service** `tests/docker/compose.providers.yml`
  - Uses `ghcr.io/mostlygeek/llama-swap:cpu` image
  - Includes `tests/docker/llamaswap-entrypoint.sh` for runtime config generation and model preloading
- **Test coverage** in `tests/providers.test.ts`
- **Docs & metadata** updated in `README.md` and `package.json`

### Test Results
```
$ PROVIDER_SUITE=llamaswap bun run test:providers
 5 pass / 0 fail

$ bun run test:providers
 25 pass / 0 fail (all providers)
```