### PR TITLE
feat: add oMLX provider support

### DIFF
--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -20,6 +20,7 @@ jobs:
           - provider: vllm
           - provider: exo
           - provider: llamaswap
+          - provider: omlx
     steps:
       - uses: actions/checkout@v4
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ import llamacpp from "./llamacpp"
 import llamaswap from "./llamaswap"
 import lmstudio from "./lmstudio"
 import ollama from "./ollama"
+import omlx from "./omlx"
 import type { ProviderMap } from "./shared"
 import vllm from "./vllm"
 
@@ -15,6 +16,7 @@ export const supportedProviders: ProviderMap = {
   vllm,
   exo,
   llamaswap,
+  omlx,
 }
 
 export const supportedProviderDefaultURLs: Record<LocalProviderKind, string> = {
@@ -24,6 +26,7 @@ export const supportedProviderDefaultURLs: Record<LocalProviderKind, string> = {
   vllm: "http://127.0.0.1:8000",
   exo: "http://127.0.0.1:52415",
   llamaswap: "http://127.0.0.1:8080",
+  omlx: "http://127.0.0.1:8000",
 }
 
 export const supportedProviderKinds = Object.keys(supportedProviders) as LocalProviderKind[]

--- a/src/providers/omlx.ts
+++ b/src/providers/omlx.ts
@@ -44,13 +44,17 @@ async function probe(url: string): Promise<LocalModel[]> {
   const body = StatusResponseSchema.parse(await res.json())
 
   return body.models
-    .filter((m) => m.loaded === true)
+    .filter((m) => {
+      if (m.loaded !== true) return false
+      const t = m.model_type ?? ""
+      return t === "llm" || t === "vlm"
+    })
     .map((m) => {
       const modelType = m.model_type ?? ""
       return {
         id: m.id,
         context: m.max_context_window ?? 0,
-        toolcall: modelType === "llm" || modelType === "vlm",
+        toolcall: true,
         vision: modelType === "vlm",
       }
     })

--- a/src/providers/omlx.ts
+++ b/src/providers/omlx.ts
@@ -1,0 +1,64 @@
+import { z } from "zod"
+import type { LocalModel } from "../types"
+import type { ProviderImpl } from "./shared"
+
+const HealthSchema = z.object({
+  status: z.string().optional(),
+  engine_pool: z
+    .object({
+      model_count: z.number().optional(),
+    })
+    .optional(),
+})
+
+const StatusResponseSchema = z.object({
+  models: z.array(
+    z.object({
+      id: z.string(),
+      loaded: z.boolean().optional(),
+      model_type: z.string().optional(),
+      engine_type: z.string().optional(),
+      max_context_window: z.number().optional(),
+    }),
+  ),
+})
+
+async function detect(url: string) {
+  try {
+    const res = await fetch(url + "/health", {
+      signal: AbortSignal.timeout(2000),
+    })
+    if (!res.ok) return false
+    const parsed = HealthSchema.safeParse(await res.json())
+    return parsed.success && parsed.data.engine_pool !== undefined
+  } catch {
+    return false
+  }
+}
+
+async function probe(url: string): Promise<LocalModel[]> {
+  const res = await fetch(url + "/v1/models/status", {
+    signal: AbortSignal.timeout(3000),
+  })
+  if (!res.ok) throw new Error(`oMLX probe failed: ${res.status}`)
+  const body = StatusResponseSchema.parse(await res.json())
+
+  return body.models
+    .filter((m) => m.loaded === true)
+    .map((m) => {
+      const modelType = m.model_type ?? ""
+      return {
+        id: m.id,
+        context: m.max_context_window ?? 0,
+        toolcall: modelType === "llm" || modelType === "vlm",
+        vision: modelType === "vlm",
+      }
+    })
+}
+
+const omlx: ProviderImpl = {
+  detect,
+  probe,
+}
+
+export default omlx

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const KINDS = ["ollama", "lmstudio", "llamacpp", "vllm", "exo", "llamaswap"] as const
+export const KINDS = ["ollama", "lmstudio", "llamacpp", "vllm", "exo", "llamaswap", "omlx"] as const
 
 export type LocalProviderKind = (typeof KINDS)[number]
 

--- a/tests/docker/compose.providers.yml
+++ b/tests/docker/compose.providers.yml
@@ -108,6 +108,28 @@ services:
       retries: 60
       start_period: 30s
 
+  omlx:
+    build:
+      context: .
+      dockerfile: omlx.Dockerfile
+    environment:
+      OMLX_MODEL: mlx-community/Qwen3-0.6B-4bit
+      OMLX_MODEL_ID: qwen3-0.6b
+      OMLX_PORT: 8000
+    volumes:
+      - ./omlx-entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["bash", "/entrypoint.sh"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS http://127.0.0.1:8000/v1/models | grep -q 'qwen3-0.6b'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 60
+      start_period: 120s
+
   exo:
     build:
       context: .

--- a/tests/docker/compose.providers.yml
+++ b/tests/docker/compose.providers.yml
@@ -123,7 +123,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -fsS http://127.0.0.1:8000/v1/models | grep -q 'qwen3-0.6b'",
+          "curl -fsS http://127.0.0.1:8000/v1/models/status | python3 -c \"import json,sys; data=json.load(sys.stdin); assert any(m.get('id')=='qwen3-0.6b' and m.get('loaded') for m in data.get('models',[]))\"",
         ]
       interval: 10s
       timeout: 10s

--- a/tests/docker/omlx-entrypoint.sh
+++ b/tests/docker/omlx-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OMLX_MODEL="${OMLX_MODEL:-mlx-community/Qwen3-0.6B-4bit}"
+OMLX_MODEL_ID="${OMLX_MODEL_ID:-qwen3-0.6b}"
+OMLX_PORT="${OMLX_PORT:-8000}"
+MODEL_DIR="/app/models"
+MODEL_PATH="${MODEL_DIR}/${OMLX_MODEL_ID}"
+
+mkdir -p "${MODEL_DIR}"
+
+# Download model from HuggingFace
+echo "Downloading model ${OMLX_MODEL}..."
+python -c "
+from huggingface_hub import snapshot_download
+snapshot_download('${OMLX_MODEL}', local_dir='${MODEL_PATH}')
+"
+echo "Model downloaded to ${MODEL_PATH}"
+
+# Start oMLX
+echo "Starting oMLX..."
+omlx serve --model-dir "${MODEL_DIR}" --host 0.0.0.0 --port "${OMLX_PORT}" --no-cache &
+omlx_pid=$!
+
+cleanup() {
+  kill "$omlx_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# Wait for server to be ready
+echo "Waiting for oMLX to start..."
+until curl -fsS "http://127.0.0.1:${OMLX_PORT}/health" >/dev/null 2>&1; do
+  sleep 2
+done
+echo "oMLX server is ready"
+
+# Trigger model loading with a chat completion request
+echo "Loading model ${OMLX_MODEL_ID}..."
+curl -fsS "http://127.0.0.1:${OMLX_PORT}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\": \"${OMLX_MODEL_ID}\", \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}], \"max_tokens\": 1}" \
+  >/dev/null 2>&1 || echo "Model loading triggered (first request may fail while loading)"
+
+echo "oMLX ready with model ${OMLX_MODEL_ID}"
+wait "$omlx_pid"

--- a/tests/docker/omlx.Dockerfile
+++ b/tests/docker/omlx.Dockerfile
@@ -1,0 +1,51 @@
+# Multi-stage Dockerfile for oMLX
+# oMLX: https://github.com/jundot/omlx
+# Runs in CPU-only mode on Linux using mlx-cpu
+
+# Stage 1: Builder
+FROM python:3.11-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (needed for building git-sourced MLX packages)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Install uv for faster Python package resolution
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone oMLX repository
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/jundot/omlx.git .
+
+ENV PATH="/root/.cargo/bin:/root/.local/bin:$PATH"
+
+# Create venv and install oMLX
+ENV VIRTUAL_ENV=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+RUN uv venv /app/.venv
+RUN uv pip install .
+
+# Replace mlx (Metal) with mlx-cpu (CPU) for Linux
+RUN uv pip install mlx-cpu
+
+# Verify mlx import works with CPU backend
+RUN python -c "import mlx.core as mx; print(f'mlx: {mx.__file__}')"
+
+# Stage 2: Runtime
+FROM python:3.11-slim-bookworm AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates libgomp1 g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /src /app
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+RUN mkdir -p /app/models
+
+EXPOSE 8000

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -57,6 +57,14 @@ const suites = [
     modelID: process.env.LLAMASWAP_MODEL,
     expectedContext: 256,
   },
+  {
+    kind: "omlx",
+    service: "omlx",
+    port: 8000,
+    url: () => providerURLs.omlx!,
+    modelID: process.env.OMLX_MODEL_ID,
+    expectedContext: 32768,
+  },
 ] as const
 
 const activeSuites = selectedKind ? suites.filter((item) => item.kind === selectedKind) : suites


### PR DESCRIPTION
## Summary
- Added oMLX service to Docker Compose test infrastructure with CPU-only support via mlx-cpu
- Implemented oMLX provider with `detect` and `probe` functions
- Added oMLX to provider test matrix in GitHub Actions workflow

## Details

### Docker (`tests/docker/`)
- `omlx.Dockerfile` — Multi-stage build cloning oMLX from source, installing dependencies with uv, and layering mlx-cpu for Linux CPU-only mode
- `omlx-entrypoint.sh` — Downloads `mlx-community/Qwen3-0.6B-4bit` model and starts `omlx serve --no-cache`

### Provider (`src/providers/omlx.ts`)
- **detect**: Hits `/health` endpoint and checks for oMLX-unique `engine_pool` key — works with zero models loaded
- **probe**: Hits `/v1/models/status` endpoint, filters to loaded models, extracts context from `max_context_window`, vision from `model_type`, and tool calling from engine type

### Workflow (`.github/workflows/provider-tests.yml`)
- Added `omlx` to the provider test matrix