### PR TITLE
fix: limit llama-swap probing to loaded models

### DIFF
--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -43,6 +43,9 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - name: Run unit test suite
+        run: bun test ./tests/unit
+
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4

--- a/src/providers/llamaswap.ts
+++ b/src/providers/llamaswap.ts
@@ -14,6 +14,34 @@ const ModelsResponseSchema = z.object({
     .optional(),
 })
 
+const RunningResponseSchema = z.object({
+  running: z
+    .array(
+      z.object({
+        model: z.string(),
+        state: z.string().optional(),
+      }),
+    )
+    .optional(),
+})
+
+export async function runningModels(url: string) {
+  try {
+    const res = await fetch(url + "/running", {
+      signal: AbortSignal.timeout(1000),
+    })
+    if (!res.ok) return new Set<string>()
+    const body = RunningResponseSchema.parse(await res.json())
+    return new Set(
+      (body.running ?? [])
+        .filter((item) => !item.state || item.state === "ready")
+        .map((item) => item.model),
+    )
+  } catch {
+    return new Set<string>()
+  }
+}
+
 async function detect(url: string) {
   try {
     // llama-swap exposes /v1/models for all configured models regardless of load state.
@@ -39,12 +67,11 @@ async function probe(url: string): Promise<LocalModel[]> {
   if (!res.ok) throw new Error(`llama-swap probe failed: ${res.status}`)
   const body = ModelsResponseSchema.parse(await res.json())
   if (!body.data) throw new Error("llama-swap probe failed: no data field")
+  const loadedModels = await runningModels(url)
 
   return Promise.all(
-    body.data.map(async (item) => {
-      // Query the underlying server through llama-swap's upstream proxy.
-      const context =
-        (await runtimeContext(`${url}/upstream/${item.id}`)) ?? 0
+    body.data.filter((item) => loadedModels.has(item.id)).map(async (item) => {
+      const context = (await runtimeContext(`${url}/upstream/${item.id}`)) ?? 0
 
       return {
         id: item.id,

--- a/tests/docker/compose.providers.yml
+++ b/tests/docker/compose.providers.yml
@@ -102,12 +102,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -fsS http://127.0.0.1:8080/v1/models | grep -q 'lfm2.5-350m'",
+          "curl -fsS http://127.0.0.1:8080/running | grep -q 'lfm2.5-350m' && curl -fsS http://127.0.0.1:8080/running | grep -q '\"ready\"'",
         ]
       interval: 10s
       timeout: 10s
       retries: 60
-      start_period: 30s
+      start_period: 60s
 
   omlx:
     build:

--- a/tests/llamaswap.test.ts
+++ b/tests/llamaswap.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from "bun:test"
+
+import { runningModels } from "../src/providers/llamaswap"
+import { probe } from "../src/probe"
+
+describe("llama-swap provider", () => {
+  test("only probes upstream for loaded models", async () => {
+    const calls: string[] = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+      calls.push(url)
+
+      if (url === "http://llamaswap.test/v1/models") {
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: "loaded", owned_by: "llama-swap" },
+              { id: "idle", owned_by: "llama-swap" },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+
+      if (url === "http://llamaswap.test/running") {
+        return new Response(
+          JSON.stringify({
+            running: [{ model: "loaded", state: "ready" }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+
+      if (url === "http://llamaswap.test/upstream/loaded/props") {
+        return new Response(
+          JSON.stringify({
+            default_generation_settings: { n_ctx: 4096 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+
+      if (url === "http://llamaswap.test/upstream/loaded/slots") {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+
+      throw new Error(`Unexpected fetch: ${url} ${init?.method ?? "GET"}`)
+    }) as typeof fetch
+
+    try {
+      const result = await probe("http://llamaswap.test")
+
+      expect(await runningModels("http://llamaswap.test")).toEqual(new Set(["loaded"]))
+      expect(result.kind).toBe("llamaswap")
+      expect(result.models).toEqual([
+        { id: "loaded", context: 4096, toolcall: false, vision: false },
+      ])
+      expect(calls).toContain("http://llamaswap.test/upstream/loaded/props")
+      expect(calls).not.toContain("http://llamaswap.test/upstream/idle/props")
+      expect(calls).not.toContain("http://llamaswap.test/upstream/idle/slots")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test"
 
-import { getConfiguredTargets, getProviderTargets } from "../src/config"
-import { supportedProviderDefaultURLs } from "../src/providers"
-import { baseURL } from "../src/url"
+import { getConfiguredTargets, getProviderTargets } from "../../src/config"
+import { supportedProviderDefaultURLs } from "../../src/providers"
+import { baseURL } from "../../src/url"
 
 test("includes supported default targets by default", () => {
   const targets = getProviderTargets()

--- a/tests/unit/llamaswap.test.ts
+++ b/tests/unit/llamaswap.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test"
 
-import { runningModels } from "../src/providers/llamaswap"
-import { probe } from "../src/probe"
+import { runningModels } from "../../src/providers/llamaswap"
+import { probe } from "../../src/probe"
 
 describe("llama-swap provider", () => {
   test("only probes upstream for loaded models", async () => {


### PR DESCRIPTION
## Summary
- use llama-swap's `/running` endpoint to identify the active model set before probing upstream metadata
- return only loaded llama-swap models so OpenCode only shows models that are currently available
- add a regression test covering the loaded-model-only probing behavior

Closes #14