### PR TITLE
(bug fix) repair lamacpp context query

### DIFF
--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -136,6 +136,18 @@ async function probeModelProps(url: string, id: string): Promise<LocalModel> {
   }
 }
 
+async function detect(url: string) {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(1000),
+    })
+    if (!res.ok) return false
+    return res.headers.get("Server")?.toLowerCase() === "llama.cpp"
+  } catch {
+    return false
+  }
+}
+
 async function probe(url: string): Promise<LocalModel[]> {
   const res = await fetch(url + "/v1/models", {
     signal: AbortSignal.timeout(10_000),

--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -10,12 +10,37 @@ const PropsSchema = z.object({
 
 const SlotsSchema = z.array(z.object({ n_ctx: z.number().optional() }))
 
+const PropsModelSchema = z.object({
+  default_generation_settings: z
+    .object({ n_ctx: z.number().optional() })
+    .optional(),
+  modalities: z.object({ vision: z.boolean().optional(), audio: z.boolean().optional(), video: z.boolean().optional() }).optional(),
+  chat_template_caps: z
+    .object({
+      supports_tool_calls: z.boolean().optional(),
+      supports_tools: z.boolean().optional(),
+    })
+    .optional(),
+})
+
 const ModelsResponseSchema = z.object({
   data: z
     .array(
       z.object({
         id: z.string(),
         meta: z.record(z.string(), z.unknown()).nullable().optional(),
+        architecture: z
+          .object({
+            input_modalities: z.array(z.string()).optional(),
+            output_modalities: z.array(z.string()).optional(),
+          })
+          .optional(),
+        status: z
+          .object({
+            args: z.array(z.string()).optional(),
+            preset: z.string().optional(),
+          })
+          .optional(),
       }),
     )
     .optional(),
@@ -50,37 +75,81 @@ export async function runtimeContext(url: string) {
   return null
 }
 
-async function detect(url: string) {
+function extractContextFromArgs(args?: string[]): number | null {
+  if (!args) return null
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === "--ctx-size" && !isNaN(Number(args[i + 1]))) {
+      return Number(args[i + 1])
+    }
+  }
+  return null
+}
+
+function extractContextFromPreset(preset?: string): number | null {
+  if (!preset) return null
+  const match = preset.match(/ctx-size\s*=\s*(\d+)/)
+  return match ? Number(match[1]) : null
+}
+
+async function probeModelProps(url: string, id: string): Promise<LocalModel> {
   try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(1000),
+    const res = await fetch(url + "/props?model=" + encodeURIComponent(id), {
+      signal: AbortSignal.timeout(10_000),
     })
-    if (!res.ok) return false
-    return res.headers.get("Server")?.toLowerCase() === "llama.cpp"
-  } catch {
-    return false
+    if (res.ok) {
+      const parsed = PropsModelSchema.parse(await res.json())
+      const context = parsed.default_generation_settings?.n_ctx ?? 0
+      const modalities = parsed.modalities ?? {}
+      const caps = parsed.chat_template_caps ?? {}
+
+      return {
+        id,
+        context,
+        toolcall: caps.supports_tool_calls ?? caps.supports_tools ?? false,
+        vision: modalities.vision ?? false,
+      }
+    }
+  } catch {}
+
+  const modelsRes = await fetch(url + "/v1/models", {
+    signal: AbortSignal.timeout(10_000),
+  })
+  if (!modelsRes.ok) {
+    return { id, context: 0, toolcall: false, vision: false }
+  }
+  const body = ModelsResponseSchema.parse(await modelsRes.json())
+  const item = body.data?.find((m) => m.id === id)
+
+  const context =
+    extractContextFromArgs(item?.status?.args) ??
+    extractContextFromPreset(item?.status?.preset) ??
+    0
+
+  const inputModalities = item?.architecture?.input_modalities ?? []
+  const vision = inputModalities.includes("image")
+
+  return {
+    id,
+    context: Number(context),
+    toolcall: false,
+    vision,
   }
 }
 
 async function probe(url: string): Promise<LocalModel[]> {
-  const loadedContext = await runtimeContext(url)
   const res = await fetch(url + "/v1/models", {
-    signal: AbortSignal.timeout(1000),
+    signal: AbortSignal.timeout(10_000),
   })
   if (!res.ok) throw new Error(`llama.cpp probe failed: ${res.status}`)
   const body = ModelsResponseSchema.parse(await res.json())
+  const ids = (body.data ?? []).map((item) => item.id)
 
-  return (body.data ?? []).map((item) => ({
-    id: item.id,
-    context: Number(
-      loadedContext ??
-        item.meta?.n_ctx ??
-        item.meta?.n_ctx_train ??
-        0,
-    ),
-    toolcall: false,
-    vision: false,
-  }))
+  const results: LocalModel[] = []
+  for (const id of ids) {
+    const result = await probeModelProps(url, id)
+    results.push(result)
+  }
+  return results
 }
 
 const llamacpp: ProviderImpl = {


### PR DESCRIPTION
Problem: In llama-server router mode, opencode-local-provider couldn’t detect model context lengths, so every model defaulted to ~32k context.  The plugin only read /v1/models, which doesn’t include per-model context in router mode.

Root cause: Router-mode llama-server returns context length and capabilities through /props?model=<id>, not through /v1/models. The plugin never queried /props?model= per model.

Fix: src/providers/llamacpp.ts now:

    Gets model IDs from /v1/models
    Sequentially probes each model with /props?model=<id> with a 10s timeout
    Extracts context, vision, and toolcall from props when available
    Falls back to /v1/models parsing (status.args/status.preset) when /props?model= fails
    Never skips a model — corrupted/slow models are included with fallback data

Why sequential + 10s timeout: Live testing confirmed parallel /props?model= requests return 500s and corrupt responses. Sequential calls avoid overloading the router. The 10s timeout accommodates slow/corrupted models without hanging startup.

Tradeoff: Startup is slightly slower because each model is probed sequentially. On a typical setup with a handful of models, this adds a few seconds. Models that fail /props?model= still appear in the list using fallback data from /v1/models.